### PR TITLE
Use fetch api instead of axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "type": "module",
   "dependencies": {
-    "axios": "^0.21.2",
     "crypto-js": "^3.1.9-1",
     "js-yaml": "^3.13.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,7 +342,7 @@ aws-sdk@^2.1326.0:
     uuid "8.0.0"
     xml2js "0.4.19"
 
-axios@^0.21.1, axios@^0.21.2:
+axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==


### PR DESCRIPTION
Slack の Webhook リクエストのために axios を使用していた箇所を fetch API に置き換える